### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol server that provides web content fetching capabilities.
 
 The fetch tool will truncate the response, but by using the `start_index` argument, you can specify where to start the content extraction. This lets models read a webpage in chunks, until they find the information they need.
 
+<a href="https://glama.ai/mcp/servers/cii0qwcawb"><img width="380" height="200" src="https://glama.ai/mcp/servers/cii0qwcawb/badge" alt="Fetch Server MCP server" /></a>
+
 ### Available Tools
 
 - `fetch` - Fetches a URL from the internet and extracts its contents as markdown.


### PR DESCRIPTION
This PR adds a badge for the [Fetch MCP Server](https://glama.ai/mcp/servers/cii0qwcawb) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/cii0qwcawb"><img width="380" height="200" src="https://glama.ai/mcp/servers/cii0qwcawb/badge" alt="Fetch Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.